### PR TITLE
Update to 0.2.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "spyder-kernels" %}
-{% set version = "0.2.4" %}
+{% set version = "0.2.6" %}
 {% set hash_type = "sha256" %}
-{% set hash = "d5bfc5fdbc98c8bef7910ac4a28638272179c9077a45e4b9b820ba87a916b18a" %}
+{% set hash = "26c8e9f78f90ac107ee72ccf78b2550d65d437010990aaf30396d0f90af3282c" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 2
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -25,7 +25,9 @@ requirements:
 
   run:
     - python
-    - ipykernel
+    - ipykernel >=4.8.2
+    - pyzmq >=17
+    - jupyter_client >=5.2.3
     - cloudpickle
 
 test:
@@ -36,7 +38,7 @@ about:
   home: https://www.spyder-ide.org/
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: LICENSE.txt
   summary: Jupyter kernels for Spyder's console
 
   description: |


### PR DESCRIPTION
Pinging @jjhelmus, @mingwandroid and @nehaljwani about this one.

Our new recipe is now `noarch` and it has some specific pins that avoid faulty versions of ipykernel, pyzmq and jupyter_client.