### PR TITLE
MAINT: skip problematic ipykernel 4.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
 
   run:
     - python
-    - ipykernel >=4.8.2
+    - ipykernel >=4.8.2,!=4.9.0
     - pyzmq >=17
     - jupyter_client >=5.2.3
     - cloudpickle


### PR DESCRIPTION
Unfortunately, this is a noarch build and we can't just skip it for 
windows.
XREF:
https://github.com/conda-forge/spyder-kernels-feedstock/pull/16

See this issue:
https://github.com/spyder-ide/spyder/issues/7821

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
