### PR TITLE
BUG: Fix bug with Python 3.11

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/migrations/python311.yaml
+++ b/.ci_support/migrations/python311.yaml
@@ -1,0 +1,37 @@
+migrator_ts: 1666686085
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 30
+    max_solver_attempts: 12  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+
+python:
+  - 3.11.* *_cpython
+# additional entries to add for zip_keys
+numpy:
+  - 1.23
+python_impl:
+  - cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
   noarch: python
   string: "unix_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [unix]
   string: "win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"   # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

See this error on the [migrator status page for Python 3.11](https://conda-forge.org/status/):

> spyder (3) Error: not solvable ([bot CI job](https://github.com/regro/autotick-bot/actions/runs/3735314445)): main: ['linux_64_python3.11.____cpython: Encountered problems while solving:\n - nothing provides __win needed by spyder-kernels-2.4.0-win_pyhd8ed1ab_1\n - package python_abi-3.11-2_cp311 requires python 3.11.*, but none of the providers can be installed\n',

Locally I can see it on macOS arm64 with an environment.yml:
```
name: test
channels:
- conda-forge
dependencies:
- python>=3.11
- spyder-kernels>=1.10.0
```
then:
```
$ mamba env create -n py311 -f environment.yml
...
Looking for: ["python[version='>=3.11']", "spyder-kernels[version='>=1.10.0']"]


Could not solve for environment specs
Encountered problems while solving:
  - nothing provides __win needed by spyder-kernels-2.4.0-win_pyhd8ed1ab_1
```

This PR seems to be a no-op, but maybe the build number bump is enough to create a new package that is usable with 3.11 here?