### PR TITLE
Update ipykernel version to match spyder-kernels requirement since 3.0.0b5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3.8
     - cloudpickle
-    - ipykernel >=6.23.2,<7.0.0
+    - ipykernel >=6.29.3,<7.0.0
     - ipython >=8.12.2,<9.0.0,!=8.17.1
     - jupyter_client >=7.4.9,<9.0.0
     - pyxdg >=0.26  # [unix]


### PR DESCRIPTION
Updated run requirement on `ipykernel` from >=6.23.2 to >=6.29.3, to match `spyder-kernels` requirement since 3.0.0b5.